### PR TITLE
Fix webpage crash when open on mobile device

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -30,7 +30,7 @@ export default new Vuex.Store({
   },
   mutations: {
     setNatives(state, natives) {
-      state.natives = natives;
+      setTimeout(() => state.natives = natives, 100);
     },
     setNativesStats(state, stats) {
       state.nativesCount = stats.totalNatives;


### PR DESCRIPTION
Hello  altmp/native-docs developer

Im newbie alt:v developer and last month i found problem when open https://natives.altv.mp/ on mobile device(happen to me on iphone 6s osx:13.4.1) and some android device I test.

[Problem Video on alt:v discord](https://discordapp.com/channels/371265202378899476/557307592129511444/705055364457955429)

And I fixing that problem now, its work both on apple device and android device by add timeout when set bunch of natives state (I thinks problem is about memory management on mobile device)

Please check and patch on https://natives.altv.mp if possible 

Best regards
izcream*

ps: sorry for my bad english.